### PR TITLE
README typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Motivation
 
-Solana's fee mechanism is unlike Ethereum's, in that the number of bytecode instructions execued _does not_ add to the cost of a transaction. Due to this, it is wise to design Solana code with excessive safety checks in order to minimize the chance of exploits.
+Solana's fee mechanism is unlike Ethereum's, in that the number of bytecode instructions executed _does not_ add to the cost of a transaction. Due to this, it is wise to design Solana code with excessive safety checks in order to minimize the chance of exploits.
 
 This library provides several utilities for Anchor programs to validate account structs and check for invariants.
 


### PR DESCRIPTION
`execued` -> `executed`  🙂